### PR TITLE
:bug: Fix service deduplication

### DIFF
--- a/src/Domain/Stack.php
+++ b/src/Domain/Stack.php
@@ -17,8 +17,14 @@ class Stack
     {
         $currentCount = 0;
         $desiredCount = 0;
+        $encounteredServices = [];
 
         foreach ($this->dockerClient->stackPs($stackName) as $process) {
+            if (array_key_exists($process['Name'], $encounteredServices)) {
+                continue;
+            }
+
+            $encounteredServices[$process['Name']] = true;
             $service = new Service(
                 new Service\CurrentState($process['CurrentState']),
                 new Service\DesiredState($process['DesiredState'])

--- a/tests/Units/Domain/Stack.php
+++ b/tests/Units/Domain/Stack.php
@@ -18,11 +18,58 @@ class Stack extends atoum
                     yield from
                     [
                         [
+                            'Name' => 'some_service_foo.1',
                             'CurrentState' => 'running',
                             'DesiredState' => 'running',
                         ],
                         [
+                            'Name' => 'some_service_bar.1',
                             'CurrentState' => 'running',
+                            'DesiredState' => 'shutdown',
+                        ],
+                    ];
+                }
+            )
+            ->and(
+                $stackName = 'someStack'
+            )
+            ->and(
+                $this->newTestedInstance($dockerClientMock)
+            )
+            ->when(
+                $progress = $this->testedInstance->getProgress($stackName)
+            )
+            ->then
+                ->mock($dockerClientMock)
+                    ->call('stackPs')
+                        ->withIdenticalArguments($stackName)
+                        ->once()
+                ->boolean($progress->hasConverged())
+                    ->isTrue()
+        ;
+    }
+
+    public function test it dedupe listed services the first occurrence win()
+    {
+        $this
+            ->given(
+                $dockerClientMock = new \mock\App\Domain\DockerClient(),
+                $this->calling($dockerClientMock)->stackPs = function () {
+                    yield from
+                    [
+                        [
+                            'Name' => 'some_service_foo.1',
+                            'CurrentState' => 'running',
+                            'DesiredState' => 'running',
+                        ],
+                        [
+                            'Name' => 'some_service_foo.1',
+                            'CurrentState' => 'failed',
+                            'DesiredState' => 'shutdown',
+                        ],
+                        [
+                            'Name' => 'some_service_foo.1',
+                            'CurrentState' => 'failed',
                             'DesiredState' => 'shutdown',
                         ],
                     ];
@@ -56,10 +103,12 @@ class Stack extends atoum
                     yield from
                     [
                         [
+                            'Name' => 'some_service_foo.1',
                             'CurrentState' => 'running',
                             'DesiredState' => 'running',
                         ],
                         [
+                            'Name' => 'some_service_bar.1',
                             'CurrentState' => 'failed',
                             'DesiredState' => 'running',
                         ],


### PR DESCRIPTION
We can encounter many occurence of a named service. By default docker stack ps return them in the order they've been scheduled so it perfectly fit our need and we discard duplicates we could encounter later on into the list